### PR TITLE
Fix hamburger menu import

### DIFF
--- a/src/Components/Header.tsx
+++ b/src/Components/Header.tsx
@@ -4,7 +4,7 @@ import { Dropdown } from "./Dropdown";
 import { DropdownResume } from "./DropdownResume";
 import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
-import Hamburger from 'hamburger-react'
+import { Squash as Hamburger } from 'hamburger-react'
 import { motion } from "framer-motion"
 import resume from '../assets/documents/Joao_Teixeira_Mid-level_Fullstack_Developer.pdf';
 import { useTheme } from "../contexts/ThemeContext";


### PR DESCRIPTION
### Motivation
- Fix a runtime React error (`Minified React error #130`) caused by rendering the package default object from `hamburger-react` instead of a concrete React component. 

### Description
- Replace the default import with the named `Squash` export and use it as `Hamburger` in `src/Components/Header.tsx` (`import { Squash as Hamburger } from 'hamburger-react'`).

### Testing
- `npm run build` completed successfully; `npm run lint` fails due to pre-existing Fast Refresh warnings in `src/contexts/LanguageContext.tsx` and `src/contexts/ThemeContext.tsx` (project configured with `--max-warnings 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43c79160b8832ab84ee42d90e7f9ed)