### PR TITLE
Use named exports for MUI icon and hamburger-react imports

### DIFF
--- a/src/Components/Dropdown.tsx
+++ b/src/Components/Dropdown.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { ChevronRight as ChevronRightIcon } from '@mui/icons-material';
 import { useState } from "react";
 import { useTheme } from "../contexts/ThemeContext";
 import { IHeaderTexts } from "../consts/Languange";

--- a/src/Components/DropdownResume.tsx
+++ b/src/Components/DropdownResume.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { ChevronRight as ChevronRightIcon } from '@mui/icons-material';
 import { useState } from "react";
 import resume from '/src/assets/documents/Joao_Teixeira_Mid-level_Fullstack_Developer.pdf';
 import toast from "react-hot-toast";

--- a/src/Components/Header.tsx
+++ b/src/Components/Header.tsx
@@ -4,7 +4,7 @@ import { Dropdown } from "./Dropdown";
 import { DropdownResume } from "./DropdownResume";
 import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
-import Hamburger from 'hamburger-react'
+import { Squash as Hamburger } from 'hamburger-react'
 import { motion } from "framer-motion"
 import resume from '../assets/documents/Joao_Teixeira_Mid-level_Fullstack_Developer.pdf';
 import { useTheme } from "../contexts/ThemeContext";


### PR DESCRIPTION
### Motivation
- Align imports with updated package exports to prevent module resolution issues and keep imports consistent across components.

### Description
- Replace default icon import `@mui/icons-material/ChevronRight` with the named import `{ ChevronRight as ChevronRightIcon }` from `@mui/icons-material` in `Dropdown.tsx` and `DropdownResume.tsx`, and change the default `Hamburger` import to the named `Squash` import from `hamburger-react` in `Header.tsx`.

### Testing
- Ran TypeScript type-check with `tsc --noEmit`, linting with `npm run lint`, and a build with `npm run build`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43c79160b8832ab84ee42d90e7f9ed)